### PR TITLE
Adding optional internal redis instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Deer Spangle <deer@spangle.org.uk>
 
 ENV BUILD_PACKAGES bash curl-dev ruby-dev build-base
 ENV RUBY_PACKAGES ruby ruby-dev ruby-bigdecimal ruby-json ruby-io-console ruby-bundler
+ENV REDIS_PACKAGES redis
 
 # Update and install all of the required packages.
 # At the end, remove the apk cache
@@ -10,6 +11,7 @@ RUN apk update && \
     apk upgrade && \
     apk add $BUILD_PACKAGES && \
     apk add $RUBY_PACKAGES && \
+    apk add $REDIS_PACKAGES && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir /usr/faexport
@@ -23,4 +25,5 @@ COPY . /usr/faexport
 
 EXPOSE 9292/tcp
 
-CMD bundle exec rackup config.ru -p 9292 --host 0.0.0.0
+#CMD bundle exec rackup config.ru -p 9292 --host 0.0.0.0
+ENTRYPOINT ["sh","/usr/faexport/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+#check if REDIS_URL is empty
+if [  -z "$REDIS_URL" ]; then
+    #run the redis-server in the background
+    redis-server &
+fi
+
+#run faexport and listen on all ips and port 9292
+bundle exec rackup config.ru -p 9292 --host 0.0.0.0


### PR DESCRIPTION
This this adds the option to run redis inside the faexport container if the environment variable REDIS_URL is not set.